### PR TITLE
Add basic SAST web project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
-# SAST
-This is a test repo
+# SAST App
+
+This project provides a simple web application for managing SAST (Static Application Security Testing) tasks and displaying scan reports. The backend is written in Go and uses MySQL for data storage. A minimal HTML page is included for interacting with the API.
+
+## Project Layout
+
+- **cmd/server** – main application entry point.
+- **internal/** – backend packages (database setup, HTTP handlers and models).
+- **web/** – static files served to the client.
+
+## Building
+
+Ensure Go is installed and run:
+
+```bash
+go mod tidy
+go build ./cmd/server
+```
+
+`MYSQL_DSN` environment variable controls the database connection (default is `root:password@tcp(localhost:3306)/sast`).
+
+## Running
+
+Start the server and open `web/index.html` in a browser:
+
+```bash
+./server
+```
+
+The page allows creating new tasks and viewing reports in a clean and simple interface.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+    "log"
+    "net/http"
+    "os"
+
+    "sast/internal/db"
+    "sast/internal/handlers"
+)
+
+func main() {
+    dsn := os.Getenv("MYSQL_DSN")
+    if dsn == "" {
+        dsn = "root:password@tcp(localhost:3306)/sast"
+    }
+
+    database, err := db.New(dsn)
+    if err != nil {
+        log.Fatalf("db connection failed: %v", err)
+    }
+    defer database.Close()
+
+    http.HandleFunc("/tasks", handlers.TaskHandler(database))
+    http.HandleFunc("/reports", handlers.ReportHandler(database))
+
+    log.Println("server listening on :8080")
+    log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module sast
+
+go 1.23.8

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,0 +1,11 @@
+package db
+
+import (
+    "database/sql"
+    _ "github.com/go-sql-driver/mysql"
+)
+
+// New opens a database connection using the given DSN.
+func New(dsn string) (*sql.DB, error) {
+    return sql.Open("mysql", dsn)
+}

--- a/internal/handlers/report.go
+++ b/internal/handlers/report.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+    "database/sql"
+    "encoding/json"
+    "net/http"
+
+    "sast/internal/models"
+)
+
+// ReportHandler returns reports for a given task.
+func ReportHandler(db *sql.DB) http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        taskID := r.URL.Query().Get("task_id")
+        if taskID == "" {
+            http.Error(w, "task_id is required", http.StatusBadRequest)
+            return
+        }
+        rows, err := db.Query("SELECT id, task_id, content FROM reports WHERE task_id=?", taskID)
+        if err != nil {
+            http.Error(w, err.Error(), http.StatusInternalServerError)
+            return
+        }
+        defer rows.Close()
+
+        var reports []models.Report
+        for rows.Next() {
+            var rp models.Report
+            if err := rows.Scan(&rp.ID, &rp.TaskID, &rp.Content); err != nil {
+                http.Error(w, err.Error(), http.StatusInternalServerError)
+                return
+            }
+            reports = append(reports, rp)
+        }
+        json.NewEncoder(w).Encode(reports)
+    }
+}

--- a/internal/handlers/task.go
+++ b/internal/handlers/task.go
@@ -1,0 +1,48 @@
+package handlers
+
+import (
+    "database/sql"
+    "encoding/json"
+    "net/http"
+
+    "sast/internal/models"
+)
+
+// TaskHandler handles creation of new tasks.
+func TaskHandler(db *sql.DB) http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        switch r.Method {
+        case http.MethodPost:
+            var t models.Task
+            if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
+                http.Error(w, err.Error(), http.StatusBadRequest)
+                return
+            }
+            if _, err := db.Exec("INSERT INTO tasks(name, created_at) VALUES (?, NOW())", t.Name); err != nil {
+                http.Error(w, err.Error(), http.StatusInternalServerError)
+                return
+            }
+            w.WriteHeader(http.StatusCreated)
+        case http.MethodGet:
+            rows, err := db.Query("SELECT id, name, created_at FROM tasks ORDER BY id DESC")
+            if err != nil {
+                http.Error(w, err.Error(), http.StatusInternalServerError)
+                return
+            }
+            defer rows.Close()
+
+            var tasks []models.Task
+            for rows.Next() {
+                var t models.Task
+                if err := rows.Scan(&t.ID, &t.Name, &t.CreatedAt); err != nil {
+                    http.Error(w, err.Error(), http.StatusInternalServerError)
+                    return
+                }
+                tasks = append(tasks, t)
+            }
+            json.NewEncoder(w).Encode(tasks)
+        default:
+            http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+        }
+    }
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,0 +1,17 @@
+package models
+
+import "time"
+
+// Task represents a SAST scanning task.
+type Task struct {
+    ID        int64     `json:"id"`
+    Name      string    `json:"name"`
+    CreatedAt time.Time `json:"created_at"`
+}
+
+// Report represents the scan result associated with a task.
+type Report struct {
+    ID      int64  `json:"id"`
+    TaskID  int64  `json:"task_id"`
+    Content string `json:"content"`
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>SAST Dashboard</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 40px; }
+.container { max-width: 600px; margin: auto; }
+input[type=text] { width: 100%; padding: 8px; margin-bottom: 8px; }
+button { padding: 8px 16px; }
+ul { list-style: none; padding: 0; }
+li { margin-bottom: 4px; }
+pre { background: #eee; padding: 8px; }
+</style>
+</head>
+<body>
+<div class="container">
+<h1>SAST Task Manager</h1>
+<input id="taskName" type="text" placeholder="New Task Name" />
+<button onclick="createTask()">Create Task</button>
+<h2>Tasks</h2>
+<ul id="taskList"></ul>
+<h2>Reports</h2>
+<pre id="reports"></pre>
+</div>
+<script>
+async function createTask() {
+  const name = document.getElementById('taskName').value;
+  await fetch('/tasks', { method: 'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify({name}) });
+  loadTasks();
+}
+
+async function loadTasks() {
+  const res = await fetch('/tasks');
+  const tasks = await res.json();
+  const list = document.getElementById('taskList');
+  list.innerHTML = '';
+  tasks.forEach(t => {
+    const li = document.createElement('li');
+    const link = document.createElement('a');
+    link.href = '#';
+    link.textContent = t.name + ' (id ' + t.id + ')';
+    link.onclick = () => loadReports(t.id);
+    li.appendChild(link);
+    list.appendChild(li);
+  });
+}
+
+async function loadReports(id) {
+  const res = await fetch('/reports?task_id=' + id);
+  const reports = await res.json();
+  document.getElementById('reports').textContent = JSON.stringify(reports, null, 2);
+}
+
+loadTasks();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- initialize Go module
- implement basic MySQL-backed API for tasks and reports
- add simple frontend page
- document build and run instructions

## Testing
- `go vet ./...` *(fails: no required module provides package github.com/go-sql-driver/mysql)*
- `go test ./...` *(fails: no required module provides package github.com/go-sql-driver/mysql)*

------
https://chatgpt.com/codex/tasks/task_e_685639d7ba8c8332a3149e77d114943f